### PR TITLE
Fix stacklevel in trace logger

### DIFF
--- a/src/powerflex_logging_utilities/trace_logger.py
+++ b/src/powerflex_logging_utilities/trace_logger.py
@@ -19,7 +19,7 @@ class TraceLogger(logging.Logger):
         *args: object,
         exc_info: bool = False,
         stack_info: bool = False,
-        stacklevel: int = 0,
+        stacklevel: int = 2,
         extra: Union[Mapping[str, object], None] = None,
     ) -> None:
         """Log at the trace severity level.


### PR DESCRIPTION
Default trace stacklevel to 2 so it prints the file/line number of the function that called logger.trace() rather than the file/line number of the trace function.  Ie it prints this:

  {"name": "traffic_manager", "message": "TXStatusSubscriber got tx_status with extra_info={'deliver_status': 4144, 'deliver_description': None}", "module": "publisher", "lineno": 114, "funcName": "callback", "filename": "publisher.py", "asctime": "2023-02-09 19:06:13,949", "severity": "TRACE"}
  
Instead of this:
  {"name": "traffic_manager", "message": "XXX:TXStatusSubscriber got tx_status with extra_info={'deliver_status': 4144, 'deliver_description': None}", "module": "trace_logger", "lineno": 29, "funcName": "trace", "filename": "trace_logger.py", "asctime": "2023-02-09 19:04:10,984", "severity": "TRACE"}